### PR TITLE
Removed MappingProfile Configure method and moved the code to the con…

### DIFF
--- a/Source/Mapping.AutoMapper/Mapping.AutoMapper.nuspec
+++ b/Source/Mapping.AutoMapper/Mapping.AutoMapper.nuspec
@@ -7,6 +7,6 @@
     <description>$description$</description>
     <projectUrl>https://github.com/affecto/dotnet-Mapping</projectUrl>
     <tags>affecto map mapping AutoMapper</tags>
-    <releaseNotes>Updated to AutoMapper 5.0.2 to fix weird MissingMethodExceptions.</releaseNotes>
+    <releaseNotes>Removed MappingProfile Configure method and moved the code to the constructor instead.</releaseNotes>
   </metadata>
 </package>

--- a/Source/Mapping.AutoMapper/MappingProfile.cs
+++ b/Source/Mapping.AutoMapper/MappingProfile.cs
@@ -5,18 +5,18 @@ namespace Affecto.Mapping.AutoMapper
 {
     public abstract class MappingProfile<TSource, TDestination> : Profile, IMappingProfile<TSource, TDestination>
     {
+        protected MappingProfile()
+        {
+            IMappingExpression<TSource, TDestination> map = CreateMap<TSource, TDestination>();
+            ConfigureMapping(map);
+        }
+
         public virtual IMapper<TSource, TDestination> CreateMapper(IMapper mapper)
         {
             return new Mapper(mapper);
         }
 
         protected abstract void ConfigureMapping(IMappingExpression<TSource, TDestination> map);
-
-        protected override void Configure()
-        {
-            IMappingExpression<TSource, TDestination> map = CreateMap<TSource, TDestination>();
-            ConfigureMapping(map);
-        }
 
         public class Mapper : IMapper<TSource, TDestination>
         {

--- a/Source/Mapping.AutoMapper/Properties/AssemblyInfo.cs
+++ b/Source/Mapping.AutoMapper/Properties/AssemblyInfo.cs
@@ -4,8 +4,8 @@
 [assembly: AssemblyDescription("AutoMapper implementation for one-way and two-way mapper interfaces defined in Affecto.Mapping NuGet.")]
 [assembly: AssemblyCompany("Affecto")]
 
-[assembly: AssemblyVersion("3.0.1.0")]
-[assembly: AssemblyFileVersion("3.0.1.0")]
+[assembly: AssemblyVersion("3.0.2.0")]
+[assembly: AssemblyFileVersion("3.0.2.0")]
 
 // This version is used by NuGet:
-[assembly: AssemblyInformationalVersion("3.0.1")]
+[assembly: AssemblyInformationalVersion("3.0.2")]


### PR DESCRIPTION
…structor instead.

Works at least in my project with AutoMapper 6.

A bit clumsy to call the abstract method in the constructor making it possible to include even heavy operations in the construction of concrete profile implementations. But that's where AutoMapper wants profile creation and configuration to be as far as I've understood.