### PR TITLE
Easier bootstrapping if used without Autofac

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ internal class PersonProfile : MappingProfile<IPerson, Person>
 }
 ```
 
+#### Bootstrapping mapper factory without using Autofac container and requesting mappers
+
+Create a mapper factory instance and register your mapping profiles. Store mapper factory as a singleton.
+
+```csharp
+var mapperFactory = new MapperFactory(new PersonProfile(), new AddressProfile());
+IMapper<IPerson, Person> mapper = mapperFactory.Create<IPerson, Person>();
+```
+
 #### Registering mapping profiles to Autofac container using extension method
 
 ```csharp
@@ -107,6 +116,33 @@ internal class CustomMapperConfigurationFactory : MapperConfigurationFactory
     {
         base.AddCustomConfiguration(configuration);
         configuration.DestinationMemberNamingConvention = new LowerUnderscoreNamingConvention();
+    }
+}
+```
+
+#### Requesting mappers from Autofac container
+
+Using standard constructor injection, you can either inject a mapper instance and use it directly:
+
+```csharp
+public class SomeService
+{
+    public SomeService(IMapper<IPerson, Person> personMapper)
+    {
+        // Use mapper directly...
+    }
+}
+```
+
+...or inject a mapper factory instance and request mappers from it:
+
+```csharp
+public class SomeService
+{
+    public SomeService(IMapperFactory mapperFactory)
+    {
+        IMapper<IPerson, Person> personMapper = mapperFactory.Create<IPerson, Person>();
+        // Use mapper here...
     }
 }
 ```

--- a/Source/Mapping.AutoMapper.Tests/MapperConfigurationFactoryTests.cs
+++ b/Source/Mapping.AutoMapper.Tests/MapperConfigurationFactoryTests.cs
@@ -18,7 +18,7 @@ namespace Affecto.Mapping.AutoMapper.Tests
         [TestMethod]
         public void MapperIsConfiguredWithAssemblyProfiles()
         {
-            TestMappingProfile testMappingProfile = new TestMappingProfile();
+            TestMappingProfile1 testMappingProfile = new TestMappingProfile1();
             MapperConfiguration mapperConfiguration = sut.CreateMapperConfiguration(Assembly.GetExecutingAssembly());
 
             IMapper<Class1, Class2> mapper = testMappingProfile.CreateMapper(mapperConfiguration.CreateMapper());
@@ -28,22 +28,5 @@ namespace Affecto.Mapping.AutoMapper.Tests
             Assert.IsNotNull(result);
             Assert.AreEqual("Value", result.Prop);
         }
-    }
-
-    public class TestMappingProfile : MappingProfile<Class1, Class2>
-    {
-        protected override void ConfigureMapping(IMappingExpression<Class1, Class2> map)
-        {
-        }
-    }
-
-    public class Class1
-    {
-        public string Prop { get; set; }
-    }
-
-    public class Class2
-    {
-        public string Prop { get; set; }
     }
 }

--- a/Source/Mapping.AutoMapper.Tests/MapperFactoryTests.cs
+++ b/Source/Mapping.AutoMapper.Tests/MapperFactoryTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using AutoMapper;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Affecto.Mapping.AutoMapper.Tests
+{
+    [TestClass]
+    public class MapperFactoryTests
+    {
+        private MapperFactory sut;
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void CannotInstantiateFactoryWithoutProfiles()
+        {
+            sut = new MapperFactory(new List<Profile>());
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void CannotInstantiateFactoryWithNullProfiles()
+        {
+            sut = new MapperFactory((Profile) null);
+        }
+
+        [TestMethod]
+        public void RegisteredMappersAreCreated()
+        {
+            sut = new MapperFactory(new TestMappingProfile1(), new TestMappingProfile2());
+
+            IMapper<Class1, Class2> mapper1 = sut.Create<Class1, Class2>();
+            IMapper<Class2, Class1> mapper2 = sut.Create<Class2, Class1>();
+
+            Assert.IsNotNull(mapper1);
+            Assert.IsNotNull(mapper2);
+            Assert.IsInstanceOfType(mapper1, typeof(TestMappingProfile1.Mapper));
+            Assert.IsInstanceOfType(mapper2, typeof(TestMappingProfile2.Mapper));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void UnregisteredMappersAreNotCreated()
+        {
+            sut = new MapperFactory(new TestMappingProfile2());
+
+            sut.Create<Class1, Class2>();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void CannotRegisterMultipleMappersForSameTypes()
+        {
+            sut = new MapperFactory(new TestMappingProfile1(), new TestMappingProfile1());
+
+            sut.Create<Class1, Class2>();
+        }
+    }
+}

--- a/Source/Mapping.AutoMapper.Tests/MapperFactoryTests.cs
+++ b/Source/Mapping.AutoMapper.Tests/MapperFactoryTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using AutoMapper;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Affecto.Mapping.AutoMapper.Tests
@@ -14,14 +13,14 @@ namespace Affecto.Mapping.AutoMapper.Tests
         [ExpectedException(typeof(ArgumentException))]
         public void CannotInstantiateFactoryWithoutProfiles()
         {
-            sut = new MapperFactory(new List<Profile>());
+            sut = new MapperFactory(new List<MappingProfile>());
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
         public void CannotInstantiateFactoryWithNullProfiles()
         {
-            sut = new MapperFactory((Profile) null);
+            sut = new MapperFactory((MappingProfile) null);
         }
 
         [TestMethod]

--- a/Source/Mapping.AutoMapper.Tests/Mapping.AutoMapper.Tests.csproj
+++ b/Source/Mapping.AutoMapper.Tests/Mapping.AutoMapper.Tests.csproj
@@ -77,8 +77,10 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="MapperFactoryTests.cs" />
     <Compile Include="MapperConfigurationFactoryTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestMappingProfile.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Mapping.AutoMapper\Mapping.AutoMapper.csproj">

--- a/Source/Mapping.AutoMapper.Tests/TestMappingProfile.cs
+++ b/Source/Mapping.AutoMapper.Tests/TestMappingProfile.cs
@@ -1,0 +1,28 @@
+﻿using AutoMapper;
+
+namespace Affecto.Mapping.AutoMapper.Tests
+{
+    internal class TestMappingProfile1 : MappingProfile<Class1, Class2>
+    {
+        protected override void ConfigureMapping(IMappingExpression<Class1, Class2> map)
+        {
+        }
+    }
+
+    internal class TestMappingProfile2 : MappingProfile<Class2, Class1>
+    {
+        protected override void ConfigureMapping(IMappingExpression<Class2, Class1> map)
+        {
+        }
+    }
+
+    public class Class1
+    {
+        public string Prop { get; set; }
+    }
+
+    public class Class2
+    {
+        public string Prop { get; set; }
+    }
+}

--- a/Source/Mapping.AutoMapper/MapperConfigurationFactory.cs
+++ b/Source/Mapping.AutoMapper/MapperConfigurationFactory.cs
@@ -7,7 +7,7 @@ using AutoMapper;
 namespace Affecto.Mapping.AutoMapper
 {
     /// <summary>
-    /// Factory class for creating AutoMapper configuration using mapping profiles.
+    /// Factory class for creating AutoMapper configuration using mapping profiles. Derive from this class to provide custom global configuration for all mappers.
     /// </summary>
     public class MapperConfigurationFactory
     {
@@ -55,7 +55,7 @@ namespace Affecto.Mapping.AutoMapper
         }
 
         /// <summary>
-        /// Set custom AutoMapper configuration settings.
+        /// Set custom, global AutoMapper configuration settings.
         /// </summary>
         /// <param name="configuration">AutoMapper configuration.</param>
         protected virtual void AddCustomConfiguration(IMapperConfigurationExpression configuration)

--- a/Source/Mapping.AutoMapper/MapperFactory.cs
+++ b/Source/Mapping.AutoMapper/MapperFactory.cs
@@ -10,7 +10,7 @@ namespace Affecto.Mapping.AutoMapper
     /// </summary>
     public class MapperFactory : IMapperFactory
     {
-        private readonly IReadOnlyCollection<Profile> profiles;
+        private readonly IReadOnlyCollection<MappingProfile> profiles;
         private readonly IMapper mapper;
 
         /// <summary>
@@ -18,7 +18,7 @@ namespace Affecto.Mapping.AutoMapper
         /// </summary>
         /// <param name="mapperConfigurationFactory">Custom configuration factory for providing global configuration for all mappers.</param>
         /// <param name="profiles">Mapping profiles to configure specific type mappers.</param>
-        public MapperFactory(MapperConfigurationFactory mapperConfigurationFactory, IEnumerable<Profile> profiles)
+        public MapperFactory(MapperConfigurationFactory mapperConfigurationFactory, IEnumerable<MappingProfile> profiles)
         {
             if (mapperConfigurationFactory == null)
             {
@@ -49,7 +49,7 @@ namespace Affecto.Mapping.AutoMapper
         /// Construct using a collection of specified mapping profiles.
         /// </summary>
         /// <param name="profiles">Mapping profiles to configure specific type mappers.</param>
-        public MapperFactory(IEnumerable<Profile> profiles)
+        public MapperFactory(IEnumerable<MappingProfile> profiles)
             : this(new MapperConfigurationFactory(), profiles)
         {
         }
@@ -60,7 +60,7 @@ namespace Affecto.Mapping.AutoMapper
         /// <param name="mapperConfigurationFactory">Custom configuration factory for providing global configuration for all mappers.</param>
         /// <param name="profile">Mapping profile to configure specific type mapper.</param>
         /// <param name="profiles">Mapping profiles to configure specific type mappers.</param>
-        public MapperFactory(MapperConfigurationFactory mapperConfigurationFactory, Profile profile, params Profile[] profiles)
+        public MapperFactory(MapperConfigurationFactory mapperConfigurationFactory, MappingProfile profile, params MappingProfile[] profiles)
             : this(mapperConfigurationFactory, new[] { profile }.Concat(profiles))
         {
         }
@@ -70,7 +70,7 @@ namespace Affecto.Mapping.AutoMapper
         /// </summary>
         /// <param name="profile">Mapping profile to configure specific type mapper.</param>
         /// <param name="profiles">Mapping profiles to configure specific type mappers.</param>
-        public MapperFactory(Profile profile, params Profile[] profiles)
+        public MapperFactory(MappingProfile profile, params MappingProfile[] profiles)
             : this(new[] { profile }.Concat(profiles))
         {
         }
@@ -82,7 +82,7 @@ namespace Affecto.Mapping.AutoMapper
         /// <typeparam name="TDestination">Destination type to map to.</typeparam>
         public IMapper<TSource, TDestination> Create<TSource, TDestination>()
         {
-            List<IMappingProfile<TSource, TDestination>> matchingProfiles = profiles.OfType<IMappingProfile<TSource, TDestination>>().ToList();
+            List<MappingProfile<TSource, TDestination>> matchingProfiles = profiles.OfType<MappingProfile<TSource, TDestination>>().ToList();
 
             if (matchingProfiles.Count == 0)
             {

--- a/Source/Mapping.AutoMapper/MapperFactory.cs
+++ b/Source/Mapping.AutoMapper/MapperFactory.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using AutoMapper;
+
+namespace Affecto.Mapping.AutoMapper
+{
+    /// <summary>
+    /// Factory class for creating mapper instances. Use as a singleton.
+    /// </summary>
+    public class MapperFactory : IMapperFactory
+    {
+        private readonly IReadOnlyCollection<Profile> profiles;
+        private readonly IMapper mapper;
+
+        /// <summary>
+        /// Construct using a custom, derived MapperConfigurationFactory instance and a collection of specified mapping profiles.
+        /// </summary>
+        /// <param name="mapperConfigurationFactory">Custom configuration factory for providing global configuration for all mappers.</param>
+        /// <param name="profiles">Mapping profiles to configure specific type mappers.</param>
+        public MapperFactory(MapperConfigurationFactory mapperConfigurationFactory, IEnumerable<Profile> profiles)
+        {
+            if (mapperConfigurationFactory == null)
+            {
+                throw new ArgumentNullException(nameof(mapperConfigurationFactory));
+            }
+            if (profiles == null)
+            {
+                throw new ArgumentNullException(nameof(profiles));
+            }
+
+            this.profiles = profiles.ToList();
+
+            if (this.profiles.Count == 0)
+            {
+                throw new ArgumentException("Cannot instantiate MapperFactory without any mapping profiles.", nameof(profiles));
+            }
+
+            if (this.profiles.Any(p => p == null))
+            {
+                throw new ArgumentException("Cannot instantiate MapperFactory with null mapping profiles.", nameof(profiles));
+            }
+
+            var mapperConfiguration = mapperConfigurationFactory.CreateMapperConfiguration(this.profiles);
+            mapper = mapperConfiguration.CreateMapper();
+        }
+
+        /// <summary>
+        /// Construct using a collection of specified mapping profiles.
+        /// </summary>
+        /// <param name="profiles">Mapping profiles to configure specific type mappers.</param>
+        public MapperFactory(IEnumerable<Profile> profiles)
+            : this(new MapperConfigurationFactory(), profiles)
+        {
+        }
+
+        /// <summary>
+        /// Construct using a custom, derived MapperConfigurationFactory instance and specified mapping profiles.
+        /// </summary>
+        /// <param name="mapperConfigurationFactory">Custom configuration factory for providing global configuration for all mappers.</param>
+        /// <param name="profile">Mapping profile to configure specific type mapper.</param>
+        /// <param name="profiles">Mapping profiles to configure specific type mappers.</param>
+        public MapperFactory(MapperConfigurationFactory mapperConfigurationFactory, Profile profile, params Profile[] profiles)
+            : this(mapperConfigurationFactory, new[] { profile }.Concat(profiles))
+        {
+        }
+
+        /// <summary>
+        /// Construct using specified mapping profiles.
+        /// </summary>
+        /// <param name="profile">Mapping profile to configure specific type mapper.</param>
+        /// <param name="profiles">Mapping profiles to configure specific type mappers.</param>
+        public MapperFactory(Profile profile, params Profile[] profiles)
+            : this(new[] { profile }.Concat(profiles))
+        {
+        }
+
+        /// <summary>
+        /// Create a mapper instance for specific source and destination types.
+        /// </summary>
+        /// <typeparam name="TSource">Source type to map from.</typeparam>
+        /// <typeparam name="TDestination">Destination type to map to.</typeparam>
+        public IMapper<TSource, TDestination> Create<TSource, TDestination>()
+        {
+            List<IMappingProfile<TSource, TDestination>> matchingProfiles = profiles.OfType<IMappingProfile<TSource, TDestination>>().ToList();
+
+            if (matchingProfiles.Count == 0)
+            {
+                throw new ArgumentException(
+                    $"Could not find a matching mapping profile for source type '{typeof(TSource)}' and destination type '{typeof(TDestination)}'.");
+            }
+
+            if (matchingProfiles.Count > 1)
+            {
+                throw new ArgumentException(
+                    $"Found multiple matching mapping profiles for source type '{typeof(TSource)}' and destination type '{typeof(TDestination)}'.");
+            }
+
+            return matchingProfiles[0].CreateMapper(mapper);
+        }
+    }
+}

--- a/Source/Mapping.AutoMapper/Mapping.AutoMapper.csproj
+++ b/Source/Mapping.AutoMapper/Mapping.AutoMapper.csproj
@@ -5,12 +5,12 @@
     <AssemblyName>Affecto.Mapping.AutoMapper</AssemblyName>
     <RootNamespace>Affecto.Mapping.AutoMapper</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.0.0</Version>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <Version>4.1.0</Version>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <Authors>Affecto</Authors>
     <PackageTags>affecto map mapping AutoMapper</PackageTags>
     <PackageProjectUrl>https://github.com/affecto/dotnet-Mapping</PackageProjectUrl>
-    <PackageReleaseNotes>Converted to .NET Standard 2.0</PackageReleaseNotes>
+    <PackageReleaseNotes>Added MapperFactory class for easier bootstrapping.</PackageReleaseNotes>
     <Description>AutoMapper implementation for one-way and two-way mapper interfaces defined in Affecto.Mapping NuGet.</Description>
   </PropertyGroup>
 

--- a/Source/Mapping.AutoMapper/MappingProfile.cs
+++ b/Source/Mapping.AutoMapper/MappingProfile.cs
@@ -3,7 +3,11 @@ using AutoMapper;
 
 namespace Affecto.Mapping.AutoMapper
 {
-    public abstract class MappingProfile<TSource, TDestination> : Profile, IMappingProfile<TSource, TDestination>
+    public abstract class MappingProfile : Profile
+    {
+    }
+
+    public abstract class MappingProfile<TSource, TDestination> : MappingProfile, IMappingProfile<TSource, TDestination>
     {
         protected MappingProfile()
         {


### PR DESCRIPTION
Added a `MapperFactory` class to the `Affecto.Mapping.AutoMapper` package to make it easier to bootstrap your mappers if you are not using the `Affecto.Mapping.AutoMapper.Autofac` package.